### PR TITLE
Start styling banner

### DIFF
--- a/src/components/Sections/SIntro.vue
+++ b/src/components/Sections/SIntro.vue
@@ -5,16 +5,16 @@ import ATitle from '../Atoms/ATitle.vue'
 </script>
 
 <template>
-  <a-section class="dark section">
-    <a-title variant="dark" class="mb-0 mt-4">OPEN SOURCE GIRONA</a-title>
-    <h2 class="text-center text-third mb-4">2A EDICIÓ DE LA FESTA</h2>
-    <h2 class="text-center text-sm text-gray-500">GEEKS.CAT & PYTHON GIRONA</h2>
-    <p class="text-center py-4">
+  <a-section class="dark section flex flex-col justify-center items-center">
+    <a-title variant="dark" class="mb-8 text-7xl">OPEN SOURCE GIRONA</a-title>
+    <h2 class="text-center text-third m-4 text-5xl">2A EDICIÓ DE LA FESTA</h2>
+    <h2 class="text-center text-gray-500 text-3xl">GEEKS.CAT & PYTHON GIRONA</h2>
+    <p class="text-center mt-8 py-4">
       El Hacktoberfest és un <b>esdeveniment</b> anual d'un <b>mes de duració</b> creat per animar als desenvolupadors
       de tot el món a <b>participar en projectes de codi obert</b>.
     </p>
     <p class="text-center py-4">Aquest any celebrem la segona edició de la <b>Festa de l'OpenSource</b>!</p>
-    <p class="text-center pt-4 mb-4">A GRANS TRETS TINDREM:</p>
+    <p class="text-center pt-4 mb-4">Què farem?</p>
     <ul class="text-center mb-4">
       <li v-for="(item, index) in weWillHave" :key="index">{{ item }}</li>
     </ul>
@@ -33,5 +33,6 @@ ul {
 .section {
   background-image: url(../../assets/images/bg.jpg);
   background-position: bottom;
+  min-height: calc(100vh - 56px); // don't use h-screen to compute header height
 }
 </style>

--- a/src/components/Sections/SIntro.vue
+++ b/src/components/Sections/SIntro.vue
@@ -7,7 +7,7 @@ import ATitle from '../Atoms/ATitle.vue'
 <template>
   <a-section class="dark section flex flex-col justify-center items-center">
     <a-title variant="dark" class="mb-8 text-7xl">OPEN SOURCE GIRONA</a-title>
-    <h2 class="text-center text-third m-4 text-5xl">2A EDICIÓ DE LA FESTA</h2>
+    <h2 class="text-center text-third m-4 text-5xl">2a EDICIÓ DE LA FESTA</h2>
     <h2 class="text-center text-gray-500 text-3xl">GEEKS.CAT & PYTHON GIRONA</h2>
     <p class="text-center mt-8 py-4">
       El Hacktoberfest és un <b>esdeveniment</b> anual d'un <b>mes de duració</b> creat per animar als desenvolupadors


### PR DESCRIPTION
It tunes our banner to be rendered as 100% available screen height (taking care of our menu).

Spacing has been amended to center vertically the content and provide ensure that each element "breathes"

<img width="1053" alt="image" src="https://user-images.githubusercontent.com/8709244/194821578-4386f432-1516-428e-9a59-e09284f48e81.png">
