### PR TITLE
Feature/add ssg and airflow talks details

### DIFF
--- a/src/components/Sections/SDiary.vue
+++ b/src/components/Sections/SDiary.vue
@@ -37,12 +37,12 @@ import ASection from '../Atoms/ASection.vue'
             <td>10:00</td>
             <td>KickOff</td>
           </tr>
-          <tr>
+          <tr class="double-tr">
             <td>10:30</td>
             <td><i>"Control de l'automatització de tasques recurrents emprant Airflow"</i> per Pau Boix</td>
             <td rowspan="2">Marató PR</td>
           </tr>
-          <tr>
+          <tr class="double-tr">
             <td>11:30</td>
             <td><i>"ESP32 emprant C + SSL"</i> per Pablo Ridolfi</td>
           </tr>
@@ -50,11 +50,11 @@ import ASection from '../Atoms/ASection.vue'
             <td>12:30</td>
             <td colspan="4">Networking / Converses Geeks al Claustre</td>
           </tr>
-          <tr>
+          <tr class="double-tr">
             <td>13:00</td>
             <td colspan="4" class="text-center">Dinar</td>
           </tr>
-          <tr>
+          <tr class="double-tr">
             <td>15:30</td>
             <td rowspan="4">Taller Intro a Django</td>
             <td><i>"Introducció a Odoo, l'ERP de Python"</i> per Oriol Piera</td>
@@ -63,10 +63,14 @@ import ASection from '../Atoms/ASection.vue'
           </tr>
           <tr>
             <td>16:30</td>
+            <td><i>"Crea la teva web amb un Static Site Generator"</i> per Israel Saeta</td>
+          </tr>
+          <tr class="double-tr">
+            <td>17:00</td>
             <td><i>"OS datawarehouse"</i> per Jorge Salazar</td>
           </tr>
-          <tr>
-            <td>17:30</td>
+          <tr class="double-tr">
+            <td>18:00</td>
             <td>Lightning Talks</td>
           </tr>
           <tr>
@@ -93,5 +97,9 @@ td {
 
 tr {
   height: 50px;
+}
+
+tr.double-tr {
+  height: 100px;
 }
 </style>

--- a/src/content.ts
+++ b/src/content.ts
@@ -110,19 +110,22 @@ export const speakers: ISpeaker[] = [
     talk: 'Taller introducció a Django',
     summary: [
       'Vols aprendre a programar i crear les teves pròpies aplicacions web?',
-      "Durant el taller aprendrem com emprar el <a class='text-third' href='https://www.djangoproject.com/' target='_blank'>framework web Django</a> seguint la filosofia Django Girls: petits grups liderats per una mentora que segueixen el tutorial d'iniciació a Django"
+      "Durant el taller aprendrem com emprar el <a class='text-third' href='https://www.djangoproject.com/' target='_blank'>framework web Django</a> seguint la filosofia Django Girls: petits grups liderats per una mentora que segueixen el tutorial d'iniciació a Django."
     ],
     bio: [
-      'Miembro de PyLadies España, Python España y co-fundadora de LinuxChixAr, actualmente trabaja en Mática Partners como Data Engineer'
+      'Miembro de PyLadies España, Python España y co-fundadora de LinuxChixAr, actualmente trabaja en Mática Partners como Data Engineer.'
     ]
   },
   {
     name: 'Pau Boix',
     talk: "Control de l'automatització de tasques recurrents emprant Airflow",
     summary: [
-      'Introducció a <a class="text-third" target="_blank" href="https://airflow.apache.org/">Apache Airflow</a> enfocada a preparar la nostra primera pipeline.'
+      '<a class="text-third" target="_blank" href="https://airflow.apache.org/">Apache Airflow</a> és una plataforma open source de gestió de fluxes de treball.',
+      "A la presentació veurem els conceptes bàsics d'Airflow i com podem desenvolupar el nostre primer DAG."
     ],
-    bio: []
+    bio: [
+      "En Pau s'acaba de graduar com a enginyer infromàtic per la UdG i porta més d'un any treballant a Som Energia on ha realitzat el seu TFG centrat en l'implantació d'Apache Airflow a la cooperativa."
+    ]
   },
   {
     name: 'Pablo Ridolfi',
@@ -131,7 +134,7 @@ export const speakers: ISpeaker[] = [
     summary: [
       'Obtén el máximo rendimiento de tu ESP32: desarrolla aplicaciones en lenguaje C con el <a class="text-third" target="_blank" href="https://docs.espressif.com/projects/esp-idf/en/latest/esp32/">framework ESP-IDF</a>.',
       'La familia de microcontroladores ESP32 se ha vuelto un estándar de facto para el desarrollo de hardware IoT gracias a sus prestaciones de conectividad y su compatibilidad con plataformas como Arduino y Micropython.',
-      'En esta presentación abordaremos aspectos básicos del Espressif IoT Development Framework (ESP-IDF) que nos permitirá desarrollar aplicaciones en lenguaje C buscando obtener el mayor rendimiento de esta plataforma de hardware. Finalmente realizaremos un ejercicio de conectividad SSL desde un dispositivo basado en ESP32 hacia un servidor en la nube'
+      'En esta presentación abordaremos aspectos básicos del Espressif IoT Development Framework (ESP-IDF) que nos permitirá desarrollar aplicaciones en lenguaje C buscando obtener el mayor rendimiento de esta plataforma de hardware. Finalmente realizaremos un ejercicio de conectividad SSL desde un dispositivo basado en ESP32 hacia un servidor en la nube.'
     ],
     bio: [
       'Pablo es ingeniero en electrónica (Universidad Tecnológica Nacional) y magíster en sistemas embebidos (Universidad de Buenos Aires). Actualmente es lead field application engineer en Satellogic, donde es responsable por maximizar las métricas de rendimiento, confiabilidad y calidad de la flota de satélites LEO de la compañía.'
@@ -152,7 +155,7 @@ export const speakers: ISpeaker[] = [
     talk: 'OS datawarehouse',
     summary: [
       'How to create a highly operational Data Warehouse with Open-Source tools through a layered architecture that allows responding to the business needs that Data Scientists and business intelligence specialists solve.',
-      'Possible Big Data and Data Lake strategies. Proposal for the development cycle of solutions with Machine Learning'
+      'Possible Big Data and Data Lake strategies. Proposal for the development cycle of solutions with Machine Learning.'
     ],
     bio: [
       'Computer engineer Jorge Salazar Marrero with more than 13 years of experience in Data environments. I worked as Team Lead of a team of Data Analysts at Hewlett Packard Enterprise and I currently work as Team Lead of the Kave Home S.L. Data Team.'

--- a/src/content.ts
+++ b/src/content.ts
@@ -157,5 +157,19 @@ export const speakers: ISpeaker[] = [
     bio: [
       'Computer engineer Jorge Salazar Marrero with more than 13 years of experience in Data environments. I worked as Team Lead of a team of Data Analysts at Hewlett Packard Enterprise and I currently work as Team Lead of the Kave Home S.L. Data Team.'
     ]
+  },
+  {
+    name: 'Israel Saeta',
+    // linkedin: 'dukebody',
+    twitter: 'dukebody',
+    talk: 'Crea la teva web amb un Static Site Generator',
+    summary: [
+      "En els últims anys s'han anat popularitzant els Static Site Generators (SSG) com a una alternativa senzilla, eficient i segura per crear pàgines webs.",
+      'En aquesta xerrada explicarem els principis bàsics i mostrarem exemples en alguns dels sistemes de SSG més populars.'
+    ],
+    bio: [
+      'Apassionat de la informàtica des de petitet. Vaig aprendre a programar amb recursos gratuïts i llibres. Actualment treballo a TravelPerk dirigint un equip i programant en Python i una mica en JavaScript quan tinc temps :)',
+      'També he col·laborat en múltiples comunitats relacionades amb Python com PyBCN i Python España.'
+    ]
   }
 ]


### PR DESCRIPTION
Adds SSG talk

It integrates the SSG talk into the schedule and the talks list.

<img width="1004" alt="image" src="https://user-images.githubusercontent.com/8709244/196450745-b295ea65-d3e2-4c74-ba1c-d40d8705aa1a.png">


It also improves readability of the schedule matching the row size with their related time slot:

<img width="1004" alt="image" src="https://user-images.githubusercontent.com/8709244/196450421-988516cb-eaa9-4ec0-b7a7-771315143f79.png">
